### PR TITLE
Add queue size parameter for remote and local topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ parameter_polling_hz: 1
 
 **Note**: Don't add to remote or local topics the topic `/rosout`.
 
+# Additional Parameters in this fork
+For `remote_topics` and `local_topics`, there are two additional parameters you can provide after the topic name, message type, and alias name. You can also provide a boolean which represents whether the topic should latch, and also a queue_size, which defines the size of the message queue. These should be specified in the order `[<topic name>, <message type>, <alias name>, <latch>, <queue size>]`.
+
 # Example usage with Docker
 This tool came to be mainly to solve a problem with Docker containers. If you are running the Docker container that wants bidirectional communication with a ROS robot, and you are using Linux you can just add `--net host` to your `docker run` command (just after run). But if you are using a Mac [this won't work](https://github.com/docker/for-mac/issues/68). To work around it you can use this package.
 

--- a/src/rosduct/rosduct_impl.py
+++ b/src/rosduct/rosduct_impl.py
@@ -29,7 +29,7 @@ yaml_config = '''
 rosbridge_ip: 192.168.1.31
 rosbridge_port: 9090
 # Topics being published in the robot to expose locally
-remote_topics: [ ['/joint_states', 'sensor_msgs/JointState'], 
+remote_topics: [ ['/joint_states', 'sensor_msgs/JointState'],
                     ['/tf', 'tf2_msgs/TFMessage'],
                     ['/scan', 'sensor_msgs/LaserScan']
                     ]
@@ -118,26 +118,36 @@ class ROSduct(object):
             if len(r_t) == 2:
                 topic_name, topic_type = r_t
                 local_name = topic_name
+                latch = False
             elif len(r_t) == 3:
                 topic_name, topic_type, local_name = r_t
+                latch = False
+            elif len(r_t) == 4:
+                topic_name, topic_type, local_name, latch = r_t
 
             msg = ROSDuctConnection()
             msg.conn_name = topic_name
             msg.conn_type = topic_type
             msg.alias_name = local_name
+            msg.latch = latch
             self.add_remote_topic(msg)
 
         for l_t in self.local_topics:
             if len(l_t) == 2:
                 topic_name, topic_type = l_t
                 remote_name = topic_name
+                latch = False
             elif len(l_t) == 3:
                 topic_name, topic_type, remote_name = l_t
+                latch = False
+            elif len(l_t) == 4:
+                topic_name, topic_type, remote_name, latch = l_t
 
             msg = ROSDuctConnection()
             msg.conn_name = topic_name
             msg.conn_type = topic_type
             msg.alias_name = remote_name
+            msg.latch = latch
             self.add_local_topic(msg)
 
         # Services
@@ -396,7 +406,7 @@ class ROSduct(object):
                                        srv=True)
             rospy.loginfo("Waiting for server " + service_name + "...")
             rospy.wait_for_service(service_name)
-            # TODO: error handling in services...                    
+            # TODO: error handling in services...
             try:
                 resp = rosservprox.call(ros_req)
                 resp_dict = from_ROS_to_dict(resp)

--- a/src/rosduct/rosduct_impl.py
+++ b/src/rosduct/rosduct_impl.py
@@ -129,7 +129,7 @@ class ROSduct(object):
             msg.conn_name = topic_name
             msg.conn_type = topic_type
             msg.alias_name = local_name
-            msg.latch = latch
+            msg.latch = latch if latch.__class__==bool else latch.lower() == 'true'
             self.add_remote_topic(msg)
 
         for l_t in self.local_topics:
@@ -147,7 +147,7 @@ class ROSduct(object):
             msg.conn_name = topic_name
             msg.conn_type = topic_type
             msg.alias_name = remote_name
-            msg.latch = latch
+            msg.latch = latch if latch.__class__==bool else latch.lower() == 'true'
             self.add_local_topic(msg)
 
         # Services
@@ -425,37 +425,33 @@ class ROSduct(object):
         Check if the provided message types are installed.
         """
         for rt in self.remote_topics:
-            if len(rt) == 2:
-                _, topic_type = rt
-            elif len(rt) == 3:
-                _, topic_type, _ = rt
+            if len(rt) >= 2:
+                topic_type = rt[1]
+
             if not is_ros_message_installed(topic_type):
                 rospy.logwarn(
                     "{} could not be found in the system.".format(topic_type))
 
         for lt in self.local_topics:
-            if len(lt) == 2:
-                _, topic_type = lt
-            elif len(lt) == 3:
-                _, topic_type, _ = lt
+            if len(lt) >= 2:
+                topic_type = lt[1]
+
             if not is_ros_message_installed(topic_type):
                 rospy.logwarn(
                     "{} could not be found in the system.".format(topic_type))
 
         for rs in self.remote_services:
-            if len(rs) == 2:
-                _, service_type = rs
-            elif len(rs) == 3:
-                _, service_type, _ = rs
+            if len(rs) >= 2:
+                service_type = rs[1]
+
             if not is_ros_service_installed(service_type):
                 rospy.logwarn(
                     "{} could not be found in the system.".format(service_type))
 
         for ls in self.local_services:
-            if len(ls) == 2:
-                _, service_type = ls
-            elif len(ls) == 3:
-                _, service_type, _ = ls
+            if len(ls) >= 2:
+                service_type = ls[1]
+
             if not is_ros_service_installed(service_type):
                 rospy.logwarn(
                     "{} could not be found in the system.".format(service_type))

--- a/src/rosduct/rosduct_impl.py
+++ b/src/rosduct/rosduct_impl.py
@@ -119,17 +119,24 @@ class ROSduct(object):
                 topic_name, topic_type = r_t
                 local_name = topic_name
                 latch = False
+                queue_size = 1
             elif len(r_t) == 3:
                 topic_name, topic_type, local_name = r_t
                 latch = False
+                queue_size = 1
             elif len(r_t) == 4:
                 topic_name, topic_type, local_name, latch = r_t
+                queue_size = 1
+            elif len(r_t) == 5:
+                topic_name, topic_type, local_name, latch, queue_size = r_t
+
 
             msg = ROSDuctConnection()
             msg.conn_name = topic_name
             msg.conn_type = topic_type
             msg.alias_name = local_name
             msg.latch = latch if latch.__class__==bool else latch.lower() == 'true'
+            msg.queue_size = queue_size if queue_size.__class__==int else 1
             self.add_remote_topic(msg)
 
         for l_t in self.local_topics:
@@ -137,17 +144,23 @@ class ROSduct(object):
                 topic_name, topic_type = l_t
                 remote_name = topic_name
                 latch = False
+                queue_size = 1
             elif len(l_t) == 3:
                 topic_name, topic_type, remote_name = l_t
                 latch = False
+                queue_size = 1
             elif len(l_t) == 4:
                 topic_name, topic_type, remote_name, latch = l_t
+                queue_size = 1
+            elif len(l_t) == 5:
+                topic_name, topic_type, remote_name, latch, queue_size = l_t
 
             msg = ROSDuctConnection()
             msg.conn_name = topic_name
             msg.conn_type = topic_type
             msg.alias_name = remote_name
             msg.latch = latch if latch.__class__==bool else latch.lower() == 'true'
+            msg.queue_size = queue_size if queue_size.__class__==int else 1
             self.add_local_topic(msg)
 
         # Services
@@ -188,7 +201,8 @@ class ROSduct(object):
     def add_local_topic(self, msg):
         bridgepub = self.client.publisher(msg.alias_name,
                                           msg.conn_type,
-                                          latch=msg.latch)
+                                          latch=msg.latch,
+                                          queue_size=msg.queue_size)
 
         cb_l_to_r = self.create_callback_from_local_to_remote(msg.conn_name,
                                                               msg.conn_type,
@@ -217,7 +231,7 @@ class ROSduct(object):
         rospub = rospy.Publisher(msg.alias_name,
                                  get_ROS_class(msg.conn_type),
                                  # SubscribeListener added later
-                                 queue_size=1,
+                                 queue_size=msg.queue_size,
                                  latch=msg.latch)
 
         cb_r_to_l = self.create_callback_from_remote_to_local(msg.conn_name,

--- a/srv/ROSDuctConnection.srv
+++ b/srv/ROSDuctConnection.srv
@@ -2,4 +2,5 @@ string conn_name
 string conn_type
 string alias_name
 bool latch
+uint32 queue_size 
 ---


### PR DESCRIPTION
I have added an additional optional parameter for remote and local topics which allows you to specify the message queue size for remote and local topics.